### PR TITLE
Add props for custom icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Vue.js sound audio player base on Vuetify UI framework. Covers audio-tag API and
 - Support auto play, but if user didn't interact with the document first, the audio can't be played.
 - Support turn on and off audio download button.
 - Support disable the Vuetify Card style, and you can use this component in your own Vuetify Card of your page.
+- You can set custom icons supported by vuetify v-icon component.
 
 ### Demo
 
@@ -42,7 +43,7 @@ You also can use Vue plugin to install ```Vuetify``` by only one line command:
 vue add vuetify
 ```
 
-Node: Make sure you are using the default Vuetify iconfont (mdi).
+Node: Make sure you are using the default Vuetify iconfont (mdi) or override the icon attributes with some other supported by v-icon component.
 
 ### Usage
 Add below code into your ```<script>```:
@@ -73,6 +74,13 @@ And below code in the ```<template>```:
  - **autoPlay** (Boolean) (Optional, default is false): Add it to make the audio auto play, but in some web browsers maybe failed, because some browsers need user active in the page first then allow sound auto play.
  - **downloadable** (Boolean) (Optional, default is false): Add it to let the audio file can be downloaded.
  - **flat** (Boolean) (Optional, default is false): When set to true, make the Vuetify Card style to flat, that you can combine other information/image/data with this control in your page.
+ - **playIcon** (String) (Optional, default is mdi-play): Set the icon for play
+ - **pauseIcon** (String) (Optional, default is mdi-pause): Set the icon for pause
+ - **stopIcon** (String) (Optional, default is mdi-stop): Set the icon for stop
+ - **refreshIcon** (String) (Optional, default is mdi-refresh): Set the icon for refresh
+ - **downloadIcon** (String) (Optional, default is mdi-download): Set the icon for download
+ - **volumeHighIcon** (String) (Optional, default is mdi-volume-high): Set the icon for volume
+ - **volumeMuteIcon** (String) (Optional, default is mdi-volume-mute): Set the icon for mute
 
 ### Known Issues
 1. Audio play pregress bar can't support drag, only support click.
@@ -88,6 +96,7 @@ And below code in the ```<template>```:
  - ~~Fully support dark mode~~
  - ~~Add prop for Card flat~~
  - ~~Add increase or decrease volume of audio~~
+ - ~~Add props for custom icons~~
  
 ### License
 

--- a/src/vuetifyaudio.vue
+++ b/src/vuetifyaudio.vue
@@ -2,23 +2,23 @@
     <v-card style="text-align: center" :flat="flat == undefined || flat == false  ? false : true">
         <v-card-text>
             <v-btn outlined icon class="ma-2" :color="color" @click.native="playing ? pause() : play()" :disabled="!loaded">
-                <v-icon v-if="!playing || paused">mdi-play</v-icon>
-                <v-icon v-else>mdi-pause</v-icon>
+                <v-icon v-if="!playing || paused">{{ playIcon }}</v-icon>
+                <v-icon v-else>{{ pauseIcon }}</v-icon>
             </v-btn>
             <v-btn outlined icon class="ma-2" :color="color" @click.native="stop()" :disabled="!loaded">
-                <v-icon>mdi-stop</v-icon>
+                <v-icon>{{ stopIcon }}</v-icon>
             </v-btn>
             <v-btn outlined icon class="ma-2" :color="color" @click.native="mute()" :disabled="!loaded">
-                <v-icon v-if="!isMuted">mdi-volume-high</v-icon>
-                <v-icon v-else>mdi-volume-mute</v-icon>
+                <v-icon v-if="!isMuted">{{ volumeHighIcon }}</v-icon>
+                <v-icon v-else>{{ volumeMuteIcon }}</v-icon>
             </v-btn>
             <v-btn outlined icon class="ma-2" :color="color" @click.native="loaded ? download() : reload()" v-if="!loaded">
-                <v-icon>mdi-refresh</v-icon>
+                <v-icon>{{ refreshIcon }}</v-icon>
             </v-btn>
             <v-btn outlined icon class="ma-2" :color="color" @click.native="loaded ? download() : reload()" v-if="loaded && downloadable">
-                <v-icon>mdi-download</v-icon>
+                <v-icon>{{ downloadIcon }}</v-icon>
             </v-btn>
-            <v-slider v-model="playerVolume" prepend-icon="mdi-volume-high" max="1" step="0.01" min="0"></v-slider>
+            <v-slider v-model="playerVolume" :prepend-icon="volumeHighIcon" max="1" step="0.01" min="0"></v-slider>
             <v-progress-linear v-model="percentage" height="5" style="margin-top: 15px; margin-bottom: 15px;" @click.native="setPosition()" :disabled="!loaded"></v-progress-linear>
             <p>{{ currentTime }} / {{ duration }}</p>
         </v-card-text>
@@ -58,6 +58,34 @@
             downloadable: {
                 type: Boolean,
                 default: false
+            },
+            playIcon: {
+                type: String,
+                default: 'mdi-play'
+            },
+            pauseIcon: {
+                type: String,
+                default: 'mdi-pause'
+            },
+            stopIcon: {
+                type: String,
+                default: 'mdi-stop'
+            },
+            refreshIcon: {
+                type: String,
+                default: 'mdi-refresh'
+            },
+            downloadIcon: {
+                type: String,
+                default: 'mdi-download'
+            },
+            volumeHighIcon: {
+                type: String,
+                default: 'mdi-volume-high'
+            },
+            volumeMuteIcon: {
+                type: String,
+                default: 'mdi-volume-mute'
             }
         },
         computed: {


### PR DESCRIPTION
Hi there!

We use your component in some of our projects and by default we use the mdiSvg iconfont from vuetify and we cannot import the default mdi iconfont, so I included the props for overriding the default icons with any supported by vuetify v-icon component.
I thought about an array of icons but it decided to be simple and add a prop for each icon and avoid unnecessary complexity for such small change.
This change keeps the mdi as default, so it does not add any breaking change.

Thanks again for your work!